### PR TITLE
New Loan active partners and loan query fix, new loan typeahead alphabetize fix

### DIFF
--- a/backend/api/views/main.py
+++ b/backend/api/views/main.py
@@ -124,8 +124,8 @@ def get_partner_theme_list():
     """
         grabbing MFI Partner and Loan Theme
     """
-    themes = Theme.query.order_by(Theme.loan_theme).all()
-    partners = Partner.query.order_by(Partner.partner_name).all()
+    themes = Theme.query.filter_by(active=True).all()
+    partners = Partner.query.filter_by(active=True).all()
     data = {'themes':[x.loan_theme for x in themes], 'partners':[x.partner_name for x in partners]}
     return create_response(data=data, status=200)
 

--- a/frontend/src/components/NewLoan.js
+++ b/frontend/src/components/NewLoan.js
@@ -39,8 +39,8 @@ class NewLoan extends Component {
     changedFormData('error', false)
     axios.get(Variables.flaskURL + 'partnerThemeLists').then(response => {
       this.setState({
-        partner_names: response.data.result.partners,
-        loan_themes: response.data.result.themes
+        partner_names: response.data.result.partners.sort(),
+        loan_themes: response.data.result.themes.sort()
       })
     })
   }


### PR DESCRIPTION
Changed GET_LISTS endpoint to only query active entries. Changed axios query in newloan to alphabetize returned array.